### PR TITLE
devel-android: Move bazel and NDK version to ARG lines

### DIFF
--- a/devel-android/Dockerfile
+++ b/devel-android/Dockerfile
@@ -2,6 +2,8 @@ FROM tensorflow/tensorflow:latest-devel
 
 MAINTAINER Shiqi Jiang "chrisplus.jiang@gmail.com"
 
+ARG BAZEL_VERSION=3.7.0
+ARG NDK_VERSION=r21d
 
 # upgrade packages
 RUN apt update && apt upgrade -y
@@ -17,9 +19,7 @@ RUN pip install -U pip setuptools \
         matplotlib
 
 RUN mkdir -p /root/Android/Sdk/cmdline-tools/
-RUN export ANDROID_HOME=/root/Android/Sdk
-
-
+ENV ANDROID_HOME=/root/Android/Sdk
 
 RUN cd /root/Android/Sdk/cmdline-tools \
     && wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip \
@@ -28,14 +28,14 @@ RUN cd /root/Android/Sdk/cmdline-tools \
     && ./tools/bin/sdkmanager --update \
     && yes | ./tools/bin/sdkmanager --licenses \
     && ./tools/bin/sdkmanager 'build-tools;30.0.1' 'platforms;android-30' 'ndk-bundle' 'ndk;21.3.6528147' 'ndk;20.1.5948944' 'ndk;19.2.5345600' 'ndk;18.1.5063045'
+
 # RUN cd /root/Android/Sdk \
-#     && wget https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip \
-#     && unzip android-ndk-r18b-linux-x86_64.zip \
-#     && mv android-ndk-r18b ndk-bundle \
-#     && rm android-ndk-r18b-linux-x86_64.zip
+#     && wget https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux-x86_64.zip \
+#     && unzip android-ndk-${NDK_VERSION}-linux-x86_64.zip \
+#     && mv android-ndk-${NDK_VERSION} ndk-bundle \
+#     && rm android-ndk-${NDK_VERSION}-linux-x86_64.zip
 
 # RUN cd /root/Android \
-#     && wget https://github.com/bazelbuild/bazel/releases/download/0.29.1/bazel-0.29.1-installer-linux-x86_64.sh \
-#     && chmod a+x ./bazel-0.29.1-installer-linux-x86_64.sh \
-#     && ./bazel-0.29.1-installer-linux-x86_64.sh
-
+#     && wget https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh \
+#     && chmod a+x ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh \
+#     && ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh


### PR DESCRIPTION
As the title says.

The messy diff seems to be caused by LF normalization as I use LF-only under Unix environments while the previous revision contained a mixture of LF and CRLF. The main changes are line 5 and 6 on the right, as well as replacements near the bottom.